### PR TITLE
feat: add browse and review chats by agent feature

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -425,6 +425,7 @@
     "generateAgentDetailedGreeting": "Hello! I'll help you create your own agent. What would you like to create? You can write briefly or in detail.",
     "inputPromptHere": "input prompt here...",
     "agentNamePlaceholder": "better-agent",
+    "browseChats": "Browse Chats",
     "myAgents": "My Agents",
     "bookmarkedAgents": "Bookmarked Agents",
     "sharedAgents": "Shared Agents",

--- a/src/app/(chat)/agent/[id]/chats/page.tsx
+++ b/src/app/(chat)/agent/[id]/chats/page.tsx
@@ -1,0 +1,26 @@
+import { getSession } from "auth/server";
+import { agentRepository } from "lib/db/repository";
+import { notFound, redirect } from "next/navigation";
+import { AgentChatsView } from "@/components/agent/agent-chats-view";
+
+export default async function AgentChatsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id: agentId } = await params;
+  const session = await getSession();
+
+  if (!session?.user.id) {
+    redirect("/sign-in");
+  }
+
+  // Fetch the agent data to display its name and verify access
+  const agent = await agentRepository.selectAgentById(agentId, session.user.id);
+
+  if (!agent) {
+    notFound();
+  }
+
+  return <AgentChatsView agent={agent} />;
+}

--- a/src/app/api/agent/[id]/chats/route.ts
+++ b/src/app/api/agent/[id]/chats/route.ts
@@ -1,0 +1,64 @@
+import { getSession } from "auth/server";
+import { pgDb as db } from "lib/db/pg/db.pg";
+import { ChatThreadTable, ChatMessageTable } from "lib/db/pg/schema.pg";
+import { eq, and, desc, sql } from "drizzle-orm";
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await getSession();
+  const { id: agentId } = await params;
+
+  if (!session?.user?.id) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  // Get URL search params for filtering
+  const url = new URL(req.url);
+  const searchQuery = url.searchParams.get("search") || "";
+
+  // Query to get threads that have messages from the specified agent
+  const threadsWithAgent = await db
+    .selectDistinctOn([ChatThreadTable.id], {
+      threadId: ChatThreadTable.id,
+      title: ChatThreadTable.title,
+      createdAt: ChatThreadTable.createdAt,
+      userId: ChatThreadTable.userId,
+      lastMessageAt: sql<string>`MAX(${ChatMessageTable.createdAt})`.as(
+        "last_message_at",
+      ),
+    })
+    .from(ChatThreadTable)
+    .innerJoin(
+      ChatMessageTable,
+      eq(ChatThreadTable.id, ChatMessageTable.threadId),
+    )
+    .where(
+      and(
+        eq(ChatThreadTable.userId, session.user.id),
+        sql`${ChatMessageTable.metadata}->>'agentId' = ${agentId}`,
+      ),
+    )
+    .groupBy(ChatThreadTable.id)
+    .orderBy(desc(sql`last_message_at`));
+
+  // Filter by search query if provided
+  const filteredThreads = searchQuery
+    ? threadsWithAgent.filter((thread) =>
+        thread.title.toLowerCase().includes(searchQuery.toLowerCase()),
+      )
+    : threadsWithAgent;
+
+  return Response.json(
+    filteredThreads.map((row) => ({
+      id: row.threadId,
+      title: row.title,
+      userId: row.userId,
+      createdAt: row.createdAt,
+      lastMessageAt: row.lastMessageAt
+        ? new Date(row.lastMessageAt).getTime()
+        : 0,
+    })),
+  );
+}

--- a/src/components/agent/agent-chats-view.tsx
+++ b/src/components/agent/agent-chats-view.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { Agent } from "app-types/agent";
+import { ChatThread } from "app-types/chat";
+import { Avatar, AvatarFallback, AvatarImage } from "ui/avatar";
+import { Button } from "ui/button";
+import { Input } from "ui/input";
+import { ArrowLeft, Search, MessageSquare } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState, useMemo } from "react";
+import useSWR from "swr";
+import { fetcher } from "lib/utils";
+import { BACKGROUND_COLORS, EMOJI_DATA } from "lib/const";
+import { formatDistanceToNow } from "date-fns";
+import { Skeleton } from "ui/skeleton";
+
+type AgentChatsViewProps = {
+  agent: Agent;
+};
+
+type ThreadWithLastMessage = ChatThread & {
+  lastMessageAt: number;
+};
+
+export function AgentChatsView({ agent }: AgentChatsViewProps) {
+  const router = useRouter();
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const { data: threads, isLoading } = useSWR<ThreadWithLastMessage[]>(
+    `/api/agent/${agent.id}/chats`,
+    fetcher,
+    {
+      fallbackData: [],
+    },
+  );
+
+  const filteredThreads = useMemo(() => {
+    if (!threads) return [];
+    if (!searchQuery) return threads;
+
+    return threads.filter((thread) =>
+      thread.title.toLowerCase().includes(searchQuery.toLowerCase()),
+    );
+  }, [threads, searchQuery]);
+
+  const groupedThreads = useMemo(() => {
+    if (!filteredThreads) return [];
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    const lastWeek = new Date(today);
+    lastWeek.setDate(lastWeek.getDate() - 7);
+
+    const groups = {
+      today: [] as ThreadWithLastMessage[],
+      yesterday: [] as ThreadWithLastMessage[],
+      lastWeek: [] as ThreadWithLastMessage[],
+      older: [] as ThreadWithLastMessage[],
+    };
+
+    filteredThreads.forEach((thread) => {
+      const threadDate = thread.lastMessageAt
+        ? new Date(thread.lastMessageAt)
+        : new Date(thread.createdAt);
+      threadDate.setHours(0, 0, 0, 0);
+
+      if (threadDate.getTime() === today.getTime()) {
+        groups.today.push(thread);
+      } else if (threadDate.getTime() === yesterday.getTime()) {
+        groups.yesterday.push(thread);
+      } else if (threadDate.getTime() >= lastWeek.getTime()) {
+        groups.lastWeek.push(thread);
+      } else {
+        groups.older.push(thread);
+      }
+    });
+
+    return groups;
+  }, [filteredThreads]);
+
+  return (
+    <div className="flex flex-col h-full w-full max-w-4xl mx-auto p-6">
+      {/* Header */}
+      <div className="flex items-center gap-4 mb-6">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => router.push("/agents")}
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+        <div className="flex items-center gap-3">
+          <div
+            className="p-2 rounded-full ring-2 ring-border bg-background"
+            style={{
+              backgroundColor:
+                agent.icon?.style?.backgroundColor || BACKGROUND_COLORS[0],
+            }}
+          >
+            <Avatar className="size-8">
+              <AvatarImage src={agent.icon?.value || EMOJI_DATA[0]} />
+              <AvatarFallback className="bg-transparent">
+                {agent.name[0]}
+              </AvatarFallback>
+            </Avatar>
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold">{agent.name}</h1>
+            {agent.description && (
+              <p className="text-sm text-muted-foreground">
+                {agent.description}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Search Bar */}
+      <div className="relative mb-6">
+        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          type="text"
+          placeholder="Search conversations..."
+          className="pl-10"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+      </div>
+
+      {/* Thread List */}
+      <div className="flex-1 overflow-y-auto space-y-6">
+        {isLoading ? (
+          <div className="space-y-4">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3 p-4 rounded-lg">
+                <Skeleton className="h-12 w-12 rounded-full" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-4 w-3/4" />
+                  <Skeleton className="h-3 w-1/2" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : filteredThreads.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12 text-center">
+            <MessageSquare className="h-12 w-12 text-muted-foreground mb-4" />
+            <h3 className="text-lg font-medium mb-2">No conversations found</h3>
+            <p className="text-sm text-muted-foreground">
+              {searchQuery
+                ? "Try adjusting your search query"
+                : `No conversations with ${agent.name} yet`}
+            </p>
+          </div>
+        ) : (
+          <>
+            {groupedThreads.today.length > 0 && (
+              <div>
+                <h2 className="text-xs font-semibold text-muted-foreground mb-3">
+                  Today
+                </h2>
+                <div className="space-y-2">
+                  {groupedThreads.today.map((thread) => (
+                    <ThreadCard key={thread.id} thread={thread} />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {groupedThreads.yesterday.length > 0 && (
+              <div>
+                <h2 className="text-xs font-semibold text-muted-foreground mb-3">
+                  Yesterday
+                </h2>
+                <div className="space-y-2">
+                  {groupedThreads.yesterday.map((thread) => (
+                    <ThreadCard key={thread.id} thread={thread} />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {groupedThreads.lastWeek.length > 0 && (
+              <div>
+                <h2 className="text-xs font-semibold text-muted-foreground mb-3">
+                  Last 7 days
+                </h2>
+                <div className="space-y-2">
+                  {groupedThreads.lastWeek.map((thread) => (
+                    <ThreadCard key={thread.id} thread={thread} />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {groupedThreads.older.length > 0 && (
+              <div>
+                <h2 className="text-xs font-semibold text-muted-foreground mb-3">
+                  Older
+                </h2>
+                <div className="space-y-2">
+                  {groupedThreads.older.map((thread) => (
+                    <ThreadCard key={thread.id} thread={thread} />
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ThreadCard({ thread }: { thread: ThreadWithLastMessage }) {
+  const lastMessageTime = thread.lastMessageAt
+    ? new Date(thread.lastMessageAt)
+    : new Date(thread.createdAt);
+
+  return (
+    <Link href={`/chat/${thread.id}`}>
+      <div className="flex items-center gap-3 p-4 rounded-lg hover:bg-accent transition-colors cursor-pointer border border-transparent hover:border-border">
+        <MessageSquare className="h-5 w-5 text-muted-foreground flex-shrink-0" />
+        <div className="flex-1 min-w-0">
+          <h3 className="font-medium truncate">{thread.title}</h3>
+          <p className="text-xs text-muted-foreground">
+            {formatDistanceToNow(lastMessageTime, { addSuffix: true })}
+          </p>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/agent/agent-dropdown.tsx
+++ b/src/components/agent/agent-dropdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { appStore } from "@/app/store";
-import { AudioWaveformIcon, PencilLine } from "lucide-react";
+import { AudioWaveformIcon, PencilLine, MessageSquare } from "lucide-react";
 import { type PropsWithChildren, useState } from "react";
 import { Command, CommandGroup, CommandItem, CommandList } from "ui/command";
 import { Separator } from "ui/separator";
@@ -30,6 +30,16 @@ export function AgentDropdown({ agent, children, side, align }: Props) {
         <Command>
           <CommandList>
             <CommandGroup>
+              <CommandItem className="cursor-pointer p-0">
+                <Link
+                  href={`/agent/${agent.id}/chats`}
+                  className="flex items-center gap-2 w-full px-2 py-1 rounded"
+                  onClick={() => setOpen(false)}
+                >
+                  <MessageSquare className="text-foreground" />
+                  <span>{t("Agent.browseChats")}</span>
+                </Link>
+              </CommandItem>
               <CommandItem className="cursor-pointer p-0">
                 <div
                   className="flex items-center gap-2 w-full px-2 py-1 rounded"


### PR DESCRIPTION
## Summary

Implements the ability to browse, search, and filter conversations by agent.

## Changes

- Added "Browse Chats" menu option to agent dropdown
- Created API endpoint to fetch threads filtered by agent ID
- Implemented full-page agent chats view with search and date grouping
- Added translation key for "Browse Chats"

Closes #8

🤖 Generated with [Claude Code](https://claude.ai/code)